### PR TITLE
fix skip items for Renderer and other frameworks

### DIFF
--- a/frameworks/solid/src/benchmark.jsx
+++ b/frameworks/solid/src/benchmark.jsx
@@ -187,9 +187,9 @@ const Benchmark = () => {
         results.update = `${updateAvg.toFixed(2)}ms ±${updateSpread.toFixed(2)}`;
     
         await createMany(1000);
-        await warmup(updateMany, [1000, 10], 5);
+        await warmup(updateMany, 1000, 10);
         await createMany(1000);
-        const { average: skipNthAvg, spread: skipNthSpread } = await run(updateMany, [1000, 10], 5);
+        const { average: skipNthAvg, spread: skipNthSpread } = await run(updateMany, 1000, 10);
         results.skipNth = `${skipNthAvg.toFixed(2)}ms ±${skipNthSpread.toFixed(2)}`;
     
         await createMany(1000);

--- a/shared/utils/run.js
+++ b/shared/utils/run.js
@@ -41,7 +41,7 @@ export const run = (fn, argument, count = 5) => {
         const runTest = (fn, argument, count) => {
             // check if arguments is an array
             if (!Array.isArray(argument)) {
-                argument = [argument];
+                argument = [argument, count];
             }
 
             fn(...argument).then((res) => {

--- a/shared/utils/warmup.js
+++ b/shared/utils/warmup.js
@@ -22,7 +22,7 @@ export const warmup = (fn, argument, count = 5) => {
         const runWarmup = (fn, argument, count) => {
             // check if arguments is an array
             if (!Array.isArray(argument)) {
-                argument = [argument];
+                argument = [argument, count];
             }
 
             fn(...argument).then(() => {


### PR DESCRIPTION
Count was being passed in but never being sent to the function. So blits was skipping every X items, but other frameworks were processing every row not skipping any.