### PR TITLE
fix blits skipping items on update all rows

### DIFF
--- a/frameworks/blits/src/pages/Benchmark.js
+++ b/frameworks/blits/src/pages/Benchmark.js
@@ -76,10 +76,10 @@ export default Blits.Component('Benchmark', {
     },
     async testUpdateMany() {
       await createMany.call(this, 1000)
-      await warmup(updateMany.bind(this), 5)
+      await warmup(updateMany.bind(this), 0, 5)
       await createMany.call(this, 1000)
 
-      const { average: updateAvg, spread: updateSpread } = await run(updateMany.bind(this), 5)
+      const { average: updateAvg, spread: updateSpread } = await run(updateMany.bind(this), 0, 5)
       results.update = `${updateAvg.toFixed(2)}ms ±${updateSpread.toFixed(2)}`
     },
     async testSkipNth() {

--- a/frameworks/blits/src/pages/Memory.js
+++ b/frameworks/blits/src/pages/Memory.js
@@ -40,7 +40,7 @@ export default Blits.Component('Memory', {
     },
     async testCreateManyWithoutText() {
       const createRes = await createManyWithoutText.call(this, 20000)
-      results.create = createRes.time.toFixed(2) + 'ms'
+      results.create = createRes.time.toFixed(2)
     },
   },
 })


### PR DESCRIPTION
Since there was no second argument, Blits was using 5 and skipping every 5th element. Passing in 0 causes it to update every row as expected